### PR TITLE
Add sample Spring Boot server for iOS IAP verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# test-private-project
+# iOS In-App Purchase Demo
+
+This project demonstrates a simple Kotlin Spring Boot server that verifies iOS in-app purchase receipts. It exposes an endpoint that a client can call to verify a subscription receipt using Apple's `verifyReceipt` API.
+
+## Building
+
+This project uses Gradle. To build and run the tests:
+
+```bash
+./gradlew test
+```
+
+## Running
+
+To start the application locally:
+
+```bash
+./gradlew bootRun
+```
+
+The server will start on port `8080`. The `/api/ios/verify-receipt` endpoint accepts a JSON body containing the base64 `receiptData`, optional shared-secret `password`, and a flag `isSandbox` to determine which Apple endpoint to use.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    id("org.springframework.boot") version "3.1.1"
+    id("io.spring.dependency-management") version "1.1.0"
+    kotlin("jvm") version "1.8.22"
+    kotlin("plugin.spring") version "1.8.22"
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_17
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "ios-iap-demo"

--- a/src/main/kotlin/com/example/iosiapdemo/Application.kt
+++ b/src/main/kotlin/com/example/iosiapdemo/Application.kt
@@ -1,0 +1,11 @@
+package com.example.iosiapdemo
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class Application
+
+fun main(args: Array<String>) {
+    runApplication<Application>(*args)
+}

--- a/src/main/kotlin/com/example/iosiapdemo/controller/ReceiptController.kt
+++ b/src/main/kotlin/com/example/iosiapdemo/controller/ReceiptController.kt
@@ -1,0 +1,20 @@
+package com.example.iosiapdemo.controller
+
+import com.example.iosiapdemo.model.VerifyReceiptRequest
+import com.example.iosiapdemo.service.ReceiptService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/ios")
+class ReceiptController(private val receiptService: ReceiptService) {
+
+    @PostMapping("/verify-receipt")
+    fun verifyReceipt(@RequestBody request: VerifyReceiptRequest): ResponseEntity<String> {
+        val result = receiptService.verifyReceipt(request)
+        return ResponseEntity.ok(result)
+    }
+}

--- a/src/main/kotlin/com/example/iosiapdemo/model/VerifyReceiptRequest.kt
+++ b/src/main/kotlin/com/example/iosiapdemo/model/VerifyReceiptRequest.kt
@@ -1,0 +1,7 @@
+package com.example.iosiapdemo.model
+
+data class VerifyReceiptRequest(
+    val receiptData: String,
+    val password: String? = null,
+    val isSandbox: Boolean = true
+)

--- a/src/main/kotlin/com/example/iosiapdemo/service/ReceiptService.kt
+++ b/src/main/kotlin/com/example/iosiapdemo/service/ReceiptService.kt
@@ -1,0 +1,35 @@
+package com.example.iosiapdemo.service
+
+import com.example.iosiapdemo.model.VerifyReceiptRequest
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestTemplate
+
+@Service
+class ReceiptService {
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val restTemplate = RestTemplate()
+
+    fun verifyReceipt(request: VerifyReceiptRequest): String {
+        val url = if (request.isSandbox) {
+            "https://sandbox.itunes.apple.com/verifyReceipt"
+        } else {
+            "https://buy.itunes.apple.com/verifyReceipt"
+        }
+
+        val body = mapOf(
+            "receipt-data" to request.receiptData,
+            "password" to request.password
+        )
+
+        val headers = HttpHeaders()
+        headers.contentType = MediaType.APPLICATION_JSON
+        val httpEntity = HttpEntity(body, headers)
+        logger.info("Sending verifyReceipt request to $url")
+        val response = restTemplate.postForEntity(url, httpEntity, String::class.java)
+        return response.body ?: ""
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  application:
+    name: ios-iap-demo
+server:
+  port: 8080

--- a/src/test/kotlin/com/example/iosiapdemo/ApplicationTests.kt
+++ b/src/test/kotlin/com/example/iosiapdemo/ApplicationTests.kt
@@ -1,0 +1,11 @@
+package com.example.iosiapdemo
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class ApplicationTests {
+    @Test
+    fun contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- add Kotlin Spring Boot demo application
- implement receipt verification service and controller
- document build and run steps

## Testing
- `gradle build` *(fails: Plugin not found due to network)*

------
https://chatgpt.com/codex/tasks/task_e_683d47f886c8832c8471b54da32c3558